### PR TITLE
Set radix everywhere in parseInt

### DIFF
--- a/lib/Classes.js
+++ b/lib/Classes.js
@@ -194,12 +194,12 @@ var Helper = new function () {
 						try{ if(time_nr) time = seg.getEl(time_nr); }catch(eee){}
 						var result = new Date();
 						result.setTime(0);
-						result.setYear(parseInt(date.substr(0,4)));
-						result.setMonth(parseInt(date.substr(4,2))-1);
-						result.setDate(parseInt(date.substr(6,2)));
-						result.setHours(parseInt(time.substr(0,2)));
-						result.setMinutes(parseInt(time.substr(2,2)));
-						result.setSeconds(parseInt(time.substr(4,2)));
+						result.setYear(parseInt(date.substr(0,4), 10));
+						result.setMonth(parseInt(date.substr(4,2), 10)-1);
+						result.setDate(parseInt(date.substr(6,2), 10));
+						result.setHours(parseInt(time.substr(0,2), 10));
+						result.setMinutes(parseInt(time.substr(2,2), 10));
+						result.setSeconds(parseInt(time.substr(4,2), 10));
 						return result;
 					}catch(ee){
 						return null;
@@ -243,7 +243,7 @@ var DatenElementGruppe = function () {
                     parser.nextPos();
                     parser.setMarkerWithCurrentPos("start");
                     if (!parser.gotoNextValidChar("@")) throw new ParseError("Seg", "Error binary!", start_pos);
-                    var len = parseInt(parser.getTextFromMarkerToCurrentPos("start"));
+                    var len = parseInt(parser.getTextFromMarkerToCurrentPos("start"), 10);
                     parser.nextPos();
                     parser.setMarkerWithCurrentPos("start");
                     parser.setCurrentPos(parser.getCurrentPos() + len);
@@ -372,7 +372,7 @@ var DatenElementGruppe = function () {
                     parser.nextPos();
                     parser.setMarkerWithCurrentPos("start");
                     if (!parser.gotoNextValidChar("@")) throw new ParseError("Seg", "Error binary!", start_pos);
-                    var len = parseInt(parser.getTextFromMarkerToCurrentPos("start"));
+                    var len = parseInt(parser.getTextFromMarkerToCurrentPos("start"), 10);
                     parser.nextPos();
                     parser.setMarkerWithCurrentPos("start");
                     parser.setCurrentPos(parser.getCurrentPos() + len);

--- a/lib/MTParser.js
+++ b/lib/MTParser.js
@@ -240,9 +240,9 @@ module.exports = function(){
 	me.convertMTDateFormatToJS = function(date){
 		var result = new Date();
 		result.setTime(0);
-		result.setYear(parseInt("20"+date.substr(0,2)));
-		result.setMonth(parseInt(date.substr(2,2))-1);
-		result.setDate(parseInt(date.substr(4,2)));
+		result.setYear(parseInt("20"+date.substr(0,2), 10));
+		result.setMonth(parseInt(date.substr(2,2), 10)-1);
+		result.setDate(parseInt(date.substr(4,2), 10));
 		return result;
 	};
 };


### PR DESCRIPTION
First of all, thank you for this project! Its a really great work, and quite easy to use compared to other implementations of HBCI.

This is a little thing, but may save you a lot of headache in the future. The result of parseInt is implementation dependent if you don't specify the radix explicitly. If the number is starting with a zero, the some implementations will interpret it as a decimal number, and others will interpret it as an octal number.

See it on MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt 

> If the input string begins with "0", radix is eight (octal) or 10 (decimal).  Exactly which radix is chosen 
> is implementation-dependent.  ECMAScript 5 specifies that 10 (decimal) is used, but not all browsers 
> support this yet.  For this reason always specify a radix when using parseInt.

In Node.JS it will be base 10, so this will not change anything until you port it on other platforms.

I ported it to QtScript to use it in my Qt based project, which will interpret it as an octal number. On QtScript the result of parseInt('09') is 0, as there are no digit '9' in base 8.

As a result if I feed "130913" into this function:


    me.convertMTDateFormatToJS = function(date){
        var result = new Date();
        result.setTime(0);
        result.setYear(parseInt("20"+date.substr(0,2), 10));
        result.setMonth(parseInt(date.substr(2,2), 10)-1);
        result.setDate(parseInt(date.substr(4,2), 10));
        return result;
    };

The result will be 13rd December 2012. (Because December 2012 is the minus first month of 2013).