### PR TITLE
Ensure message sequence

### DIFF
--- a/lib/Classes.js
+++ b/lib/Classes.js
@@ -702,6 +702,13 @@ Exceptions.ConnectionFailedException = function(hostname){
 	};
 };
 util.inherits(Exceptions.ConnectionFailedException, Exceptions.OpenFinTSClientException);
+Exceptions.OutofSequenceMessageException = function(){
+	Exceptions.OpenFinTSClientException.call(this);
+	this.toString = function(){
+		return "You have to ensure that only one message at a time is send to the server, use libraries like async or promisses. You can send a new message as soon as the callback returns.";
+	};
+};
+util.inherits(Exceptions.OutofSequenceMessageException, Exceptions.OpenFinTSClientException);
 /*
 	.msg({ type:"",
 	ki_type:"",

--- a/lib/FinTSClient.js
+++ b/lib/FinTSClient.js
@@ -606,7 +606,7 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
 			}catch(cb_error){
 				me.log.gv.error(cb_error,{gv:"HKEND"},"Unhandled callback Error in HKEND");
 			}
-		});
+		},true);
 	};
 	
 	// SEPA kontoverbindung anfordern HKSPA, HISPA ist die antwort
@@ -1002,14 +1002,17 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
 	};
 	
 	// 
-    me.SendMsgToDestination = function(msg,callback){// Parameter für den Callback sind error,data
+    me.SendMsgToDestination = function(msg,callback,in_finishing){// Parameter für den Callback sind error,data
 		// Ensure the sequence of messages!
-		if(me.in_connection){
-			throw new Exceptions.OutofSequenceMessageException();
+		if(!in_finishing){
+			if(me.in_connection){
+				throw new Exceptions.OutofSequenceMessageException();
+			}
+			me.in_connection = true;
 		}
-		me.in_connection = true;
 		var int_callback = function(param_1,param_2){
-			me.in_connection = false;
+			if(!in_finishing)
+				me.in_connection = false;
 			callback(param_1,param_2);
 		};
 		var txt = msg.transformForSend();

--- a/lib/FinTSClient.js
+++ b/lib/FinTSClient.js
@@ -257,6 +257,7 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
     me.client_name 			= "Open-FinTS-JS-Client";
     me.client_version 		= 4;
 	me.proto_version		= 300;// 300=FinTS;220=HBCI 2.2
+	me.in_connection		= false;
 	
 	// BPD und System-Id mit Letzt benutzter Signatur ID
 	me.sys_id				= 0;
@@ -1002,6 +1003,15 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
 	
 	// 
     me.SendMsgToDestination = function(msg,callback){// Parameter für den Callback sind error,data
+		// Ensure the sequence of messages!
+		if(me.in_connection){
+			throw new Exceptions.OutofSequenceMessageException();
+		}
+		me.in_connection = true;
+		var int_callback = function(param_1,param_2){
+			me.in_connection = false;
+			callback(param_1,param_2);
+		};
 		var txt = msg.transformForSend();
 		me.debugLogMsg(txt,true);
 		var post_data = new Buffer(txt).toString("base64");
@@ -1032,10 +1042,10 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
 			try{
 				var MsgRecv = new Nachricht(me.proto_version);
 				MsgRecv.parse(clear_txt);
-				callback(null,MsgRecv);
+				int_callback(null,MsgRecv);
 			}catch(e){
 				me.log.con.error(e,"Could not parse received Message");
-				callback(e.toString(),null);
+				int_callback(e.toString(),null);
 			}
 		  });
 		});
@@ -1043,7 +1053,7 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,bankenlist,logger) {
 		req.on('error', function(){
 			// Hier wird dann weiter gemacht :)
 			me.log.con.error({host:u.hostname,port:u.port,path:u.path},"Could not connect to "+options.hostname);
-			callback(new Exceptions.ConnectionFailedException(u.hostname,u.port,u.path),null);
+			int_callback(new Exceptions.ConnectionFailedException(u.hostname,u.port,u.path),null);
 		  });
 		req.write(post_data);
 		req.end();

--- a/test/test_1.js
+++ b/test/test_1.js
@@ -335,6 +335,41 @@ describe('testserver',function(){
 			myFINTSServer.proto_version = 300;
 		});
 	});
+	it('Test 9 - MsgGetKontoUmsaetze - test series calls',function(done){
+			var client = new FinTSClient(12345678,"test1","1234",bankenliste,logger("Test 9"));
+			client.EstablishConnection(mocha_catcher(done,function(error){
+				if(error){
+					throw error;
+				}else{
+					var error_checked_okay = false;
+					client.konten[0].sepa_data.should.not.equal(null);
+					client.MsgGetKontoUmsaetze(client.konten[0].sepa_data,null,null,mocha_catcher(done,function(error2,rMsg,data){
+						if(error2){
+							throw error2;
+						}else{
+							// Alles gut
+							should(data).not.equal(null);
+							data.should.be.an.Array;
+							should(data[0]).not.equal(null);
+							should(data[1]).not.equal(null);
+							data[0].schlusssaldo.value.should.equal(1223.57);
+							data[1].schlusssaldo.value.should.equal(1423.6);
+							
+							should(error_checked_okay).be.ok;
+							done();
+						}
+					}));
+					// das ist der eigentliche Test
+					try{
+						client.MsgGetKontoUmsaetze(client.konten[0].sepa_data,null,null,mocha_catcher(done,function(error2,rMsg,data){}));
+					}catch(error_to_check){
+						should(error_to_check).not.equal(null);
+						error_to_check.should.be.instanceOf(client.Exceptions.OutofSequenceMessageException);
+						error_checked_okay = true;
+					}
+				}
+			}));
+		});
 	after(function(done){
 		setTimeout(function(){done();},1000);
 	});


### PR DESCRIPTION
Pro FinTS Dialog kann zur gleichen Zeit nur eine Nachricht verschickt werden und auf dessen Antwort gewartet werden. Die API stellt nun sicher, dass dies jederzeit gewährleistet ist.

Das Readme zu dem Thema habe ich bereits vorher ergänzt.
```javascript
// Achtung: Falsche Verwendung führt zu einer Exception
client.MsgGetKontoUmsaetze(client.konten[0].sepa_data,null,null,function(error2,rMsg,data){ 
    ... do something ... } );
client.MsgGetKontoUmsaetze(client.konten[1].sepa_data,null,null,function(error2,rMsg,data){
    ... do something ... } );// Hier wird jetzt eine Exception geschmissen
client.MsgGetKontoUmsaetze(client.konten[2].sepa_data,null,null,function(error2,rMsg,data){
    ... do something ... } );// Hier wird jetzt eine Exception geschmissen
client.MsgGetKontoUmsaetze(client.konten[3].sepa_data,null,null,function(error2,rMsg,data){
    ... do something ... } );// Hier wird jetzt eine Exception geschmissen
```
Der Nutzer der API bekommt jetzt eine Exception, wenn er die Antwort vom Server nicht abwartet. Er wird dadurch auf mögliche Programmierfehler hingewiesen.