### PR TITLE
Fix SWIFT Message NewLine can be @@

### DIFF
--- a/lib/Classes.js
+++ b/lib/Classes.js
@@ -214,7 +214,7 @@ var Helper = new function () {
 				//
 				// SOURCE: http://linuxwiki.de/HBCI/F%C3%BCrEntwickler
 				// TODO: find better/official source
-				return str.replace(/[^0-9a-zA-Z ]/g, "?$&");
+				return str.replace(/[?+:]/g, "?$&");
 			};
         };
 

--- a/lib/FinTSClient.js
+++ b/lib/FinTSClient.js
@@ -811,6 +811,16 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,in_bankenlist,logger) {
 		});
 	};
 	
+	me.ConvertUmsatzeArrayToListofAllTransactions = function(umsaetze){
+		var result = new Array();
+		for(var i=0;i!=umsaetze.length;i++){
+			for(var a=0;a!=umsaetze[i].saetze.length;a++){
+				result.push(umsaetze[i].saetze[a]);
+			}
+		}
+		return result;
+	};
+	
 	/*
 		konto = {iban,bic,konto_nr,unter_konto,ctry_code,blz}
 		cb

--- a/lib/FinTSClient.js
+++ b/lib/FinTSClient.js
@@ -178,7 +178,7 @@ var encoding = require('encoding');
 			callback  (function(error,recvMsg,umsaetze))	- error == null kein Fehler
 															- recvMsg (Nachricht)
 															- umsaetze [] Enthält die Umsatz Daten mit folgendem Format
-															[{			// pro Tag ein Objekt siehe MT490 SWIFT Format
+															[{			// pro Tag ein Objekt siehe MT940 SWIFT Format
 																'refnr':"STARTUMS",		// ReferenzNummer
 																'bez_refnr':null,		// BezugsreferenzNummer
 																'konto_bez':"12345678/0000000001",	// Kontobezeichnung BLZ/Kontonr
@@ -756,7 +756,7 @@ var FinTSClient = function (in_blz,in_kunden_id,in_pin,in_bankenlist,logger) {
                     }
                     var mtparse = new MTParser();
                     mtparse.parse(txt);
-                    var umsatze = mtparse.getKontoUmsaetzeFromMT490();
+                    var umsatze = mtparse.getKontoUmsaetzeFromMT940();
                     // Callback
                     try{
                         cb(null,recvMsg,umsatze);

--- a/lib/MTParser.js
+++ b/lib/MTParser.js
@@ -33,6 +33,18 @@ module.exports = function(){
 		var msgs = [];
 		var parser = new Parser(txt);
 		
+		
+		// SWIFT Protokoll
+		// Nachrichten
+		// 	enthalten Felder :Zahl:   Trennzeichen
+		// Der Kontoauszug kann über mehrere Nachrichten verteilt werden
+		// 
+		// Trennzeichen = \r\n Kompatibilität @@
+		// Syntax:
+		// Nachrichten Begin:		\r\n-\r\n	oder @@				(optional)
+		// Feld						:Zahl: 		(\r\n oder @@)
+		// Feld Mehrfach			:Zahl:		(\r\n oder @@)(mehrfach)
+		// Nachrichten Ende:		-\r\n	oder (@@ und dann muss direkt wieder @@ als Anfang folgen)
 		while(parser.hasNext()){
 			if(parser.gotoNextValidChar(":")){
 				parser.nextPos();
@@ -45,7 +57,8 @@ module.exports = function(){
 				var val = parser.getTextFromMarkerToCurrentPos("start");
 				parser.nextPos();
 				parser.nextPos();
-				while(parser.hasNext()&&!(parser.getCurrentChar()==":"||parser.getCurrentChar()=="-")){
+				// Für Feld Mehrfach
+				while(parser.hasNext()&&!(parser.getCurrentChar()==":"||parser.getCurrentChar()=="-"||parser.getCurrentChar()=="@")){
 					parser.setMarkerWithCurrentPos("start");
 					parser.gotoNextValidString(["\r\n","@@"]);
 					val += parser.getTextFromMarkerToCurrentPos("start");
@@ -55,7 +68,8 @@ module.exports = function(){
 				cur_msg.push([tag,val]);
 			}
 			// schauen ob die Message zuende ist
-			if(parser.getCurrentChar()=="-"&&(parser.cur_pos+1>=parser.data.length||(parser.data[parser.cur_pos+1]=="\r"||parser.data[parser.cur_pos+1]=="@"))){
+			if( ( parser.cur_pos+1>=parser.data.length || ( parser.getCurrentChar()=="@" && parser.data[parser.cur_pos+1]=="@" )) ||
+				( parser.cur_pos+2>=parser.data.length || ( parser.getCurrentChar()=="-" && parser.data[parser.cur_pos+1]=="\r" && parser.data[parser.cur_pos+2]=="\n" )) ){
 				msgs.push(cur_msg);
 				cur_msg = [];
 				parser.nextPos();

--- a/lib/MTParser.js
+++ b/lib/MTParser.js
@@ -41,13 +41,13 @@ module.exports = function(){
 				var tag = parser.getTextFromMarkerToCurrentPos("start");
 				parser.nextPos();
 				parser.setMarkerWithCurrentPos("start");
-				parser.gotoNextValidChar("\n\r");
+				parser.gotoNextValidString(["\r\n","@@"]);
 				var val = parser.getTextFromMarkerToCurrentPos("start");
 				parser.nextPos();
 				parser.nextPos();
 				while(parser.hasNext()&&!(parser.getCurrentChar()==":"||parser.getCurrentChar()=="-")){
 					parser.setMarkerWithCurrentPos("start");
-					parser.gotoNextValidChar("\n\r");
+					parser.gotoNextValidString(["\r\n","@@"]);
 					val += parser.getTextFromMarkerToCurrentPos("start");
 					parser.nextPos();
 					parser.nextPos();
@@ -55,7 +55,7 @@ module.exports = function(){
 				cur_msg.push([tag,val]);
 			}
 			// schauen ob die Message zuende ist
-			if(parser.getCurrentChar()=="-"&&(parser.cur_pos+1>=parser.data.length||parser.data[parser.cur_pos+1]=="\r")){
+			if(parser.getCurrentChar()=="-"&&(parser.cur_pos+1>=parser.data.length||(parser.data[parser.cur_pos+1]=="\r"||parser.data[parser.cur_pos+1]=="@"))){
 				msgs.push(cur_msg);
 				cur_msg = [];
 				parser.nextPos();

--- a/lib/MTParser.js
+++ b/lib/MTParser.js
@@ -84,7 +84,7 @@ module.exports = function(){
 		me.msgss = msgs;
 	};
 	
-	me.getKontoUmsaetzeFromMT490 = function(){
+	me.getKontoUmsaetzeFromMT940 = function(){
 		var umsaetze = [];	
 		for(var i=0;i!=me.msgss.length;i++){
 			var msg = me.msgss[i];
@@ -106,14 +106,14 @@ module.exports = function(){
 						 break;
 					case "60F":// Anfangssaldo
 					case "60M":// Zwischensaldo
-						me.parseMT490_60a(umsatz,msg,a);
+						me.parseMT940_60a(umsatz,msg,a);
 						break;
 					case "61":// Loop
-						a = me.parseMT490_loop(umsatz,msg,a);
+						a = me.parseMT940_loop(umsatz,msg,a);
 						break;
 					case "62F":// Endsaldo
 					case "62M":// Zwischensaldo
-						me.parseMT490_62a(umsatz,msg,a);
+						me.parseMT940_62a(umsatz,msg,a);
 						break;
 				}
 			}	
@@ -122,7 +122,7 @@ module.exports = function(){
 		return umsaetze;
 	};
 	
-	me.parseMT490_60a = function(umsatz,msg,a){
+	me.parseMT940_60a = function(umsatz,msg,a){
 			var string 							= msg[a][1];
 			umsatz.anfangssaldo 				= {};
 			umsatz.anfangssaldo.isZwischensaldo	= msg[a][0][2]=="M";
@@ -131,7 +131,7 @@ module.exports = function(){
 			umsatz.anfangssaldo.currency	  	= string.substr(7,3);
 			umsatz.anfangssaldo.value			= parseFloat(string.substr(10,string.length).replace(',', '.'));
 	};
-	me.parseMT490_62a = function(umsatz,msg,a){
+	me.parseMT940_62a = function(umsatz,msg,a){
 			var string 							= msg[a][1];
 			umsatz.schlusssaldo 				= {};
 			umsatz.schlusssaldo.isZwischensaldo	= msg[a][0][2]=="M";
@@ -141,7 +141,7 @@ module.exports = function(){
 			umsatz.schlusssaldo.value			= parseFloat(string.substr(10,string.length).replace(',', '.'));
 	};
 	
-	me.parseMT490_loop = function(umsatz,msg,a){
+	me.parseMT940_loop = function(umsatz,msg,a){
 		umsatz.saetze = [];
 		for(;a<msg.length&&msg[a][0]=="61";a++){
 			var satz = {};
@@ -181,7 +181,7 @@ module.exports = function(){
 			pos = end_pos+1;
 			// 2. 86
 			a++;
-			me.parseMT490_86(satz,msg[a][1]);
+			me.parseMT940_86(satz,msg[a][1]);
 			// TODO hier gibt es auch noch eine weiter bearbeitung
 			umsatz.saetze.push(satz);
 		}
@@ -189,7 +189,7 @@ module.exports = function(){
 		return a;	
 	};
 
-	me.parseMT490_86 = function(satz,raw_verwen_zweck){
+	me.parseMT940_86 = function(satz,raw_verwen_zweck){
 			satz.is_verwendungszweck_object = raw_verwen_zweck[0]=="?"||raw_verwen_zweck[1]=="?"||raw_verwen_zweck[2]=="?"||raw_verwen_zweck[3]=="?";
 			if(satz.is_verwendungszweck_object){
 				satz.verwendungszweck = {};

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -91,6 +91,44 @@ var Parser = function (in_txt) {
             return true;
         }
     };
+	// This goes to the first char of the string
+	me.findNextValidString = function(array_of_string){
+		var orig_pos = me.cur_pos;
+		var valid_chars = "";
+		for(var i=0;i!=array_of_string.length;i++){
+			valid_chars += array_of_string[i].charAt(0);
+		}
+		var pos = me.cur_pos;
+		do{
+			pos = me.findNextValidChar(valid_chars);
+			if(pos!=-1){
+				for(var i=0;i!=array_of_string.length;i++){
+					if(array_of_string[i].charAt(0)==me.data[pos]){
+						//prüfen ob voll passt
+						var comp_str = me.data.substr(pos,array_of_string[i].length);
+						if(comp_str==array_of_string[i]){
+							// fertig
+							me.cur_pos = orig_pos;
+							return pos;
+						}
+					}
+				}
+				me.cur_pos = pos + 1;
+			}
+		}while(pos!=-1);
+		me.cur_pos = orig_pos;
+		return pos;
+	};
+	me.gotoNextValidString = function(array_of_string){
+        var pos = me.findNextValidString(array_of_string);
+        if (pos == -1) {
+            me.cur_pos = me.data.length;
+            return false;
+        } else {
+            me.cur_pos = pos;
+            return true;
+        }
+    };
     me.gotoNextValidCharButIgnoreWith = function (valid_chars, demask) {
         while (true) {
             var pos = me.findNextValidChar(valid_chars);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test_server": "node dev/Run_FinTSServer.js",
     "demo": "node examples/zeige_kontoumsaetze.js log | bunyan -l trace",
     "demo_dbg": "node-debug examples/zeige_kontoumsaetze.js  | bunyan -l trace",
-    "test_dbg": "node-debug _mocha -g 'test_real Test 1'"
+    "test_dbg": "node-debug _mocha -g 'test_real Test 1'",
+	"test_rundbg" : "node-debug _mocha"
   },
   "repository": {
     "type": "git",

--- a/test/test_1.js
+++ b/test/test_1.js
@@ -268,6 +268,17 @@ describe('testserver',function(){
 							should(data[1]).not.equal(null);
 							data[0].schlusssaldo.value.should.equal(1223.57);
 							data[1].schlusssaldo.value.should.equal(1423.6);
+							// Test converter
+							var u_list = client.ConvertUmsatzeArrayToListofAllTransactions(data);
+							should(u_list).not.equal(null);
+							u_list.should.be.an.Array;
+							should(u_list[0]).not.be.undefined;
+							should(u_list[1]).not.be.undefined;
+							should(u_list[2]).not.be.undefined;
+							should(u_list[3]).be.undefined;
+							u_list[0].value.should.equal(182.34);
+							u_list[1].value.should.equal(100.03);
+							u_list[2].value.should.equal(100.00);
 							// Testcase erweitern
 							done();
 						}


### PR DESCRIPTION
In SWIFT Nachrichten ist der Abschluss einer Zeile normalerweise mit CR LF also \r\n.
Die [Dokumentation](https://www.ksk-koeln.de/datenstruktur-mt940-swift.pdfx) sagt hierzu folgendes:
*  Eine Nachricht bzw. Teilnachricht (endet mit Feld ":62M:") wird mit X´0D2560´ (EBCDIC) in der Bank-Bank-Kommunikation bzw. X´0D0A´ oder X´0D0A2D´ (ASCII) in der Kunde-Bank-Beziehung abgeschlossen. Bei BTX nur C´@@´.
*  @@ =<CR> <LF>
Ursprünglich ist davon ausgegangen worden, dass BTX nichtmehr relevant ist, daher nur auf ein CR LF geprüft werden muss. Es ist jetzt jedoch ein Fall aufgetreten und zwar für die Bank mit der BLZ 37069521 bei der trotzdem ein @@ gesendet wurde. Diese Bank hat ein FinTS Endpoint der GAD, daher sind sicherlich alle Konten der GAD betroffen.

Mit diesem Pullrequest werden jetzt auch @@ als Abschluss berücksichtigt.
